### PR TITLE
支持多个servant

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,13 @@ onRequest方法:
 * phptars/tars-config: 负责对于平台上传的配置的拉取
 
 ## Changelog
+### v0.3.0(2019-06-21)
+- 至此多个servant
+- 使用swoole addListener 做底层支持
+- 支持一个服务部署多个obj，分别使用tars 或 http 协议
+- services.php 格式调整，返回以objName 为key 的二维数组。
+- protocolName, serverType, isTimer 不在从私有模板中读取，需要在services.php中指定
+
 ### v0.2.4(2019-03-20)
 - 按照psr规则格式化代码
 - 修复代码中的bug

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ onRequest方法:
 
 ## Changelog
 ### v0.3.0(2019-06-21)
-- 至此多个servant
+- 支持多个servant
 - 使用swoole addListener 做底层支持
 - 支持一个服务部署多个obj，分别使用tars 或 http 协议
 - services.php 格式调整，返回以objName 为key 的二维数组。

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "phptars/tars-server",
     "description": "tars的php框架",
-    "version":"0.2.5",
+    "version":"0.3.0",
     "authors": [
         {
             "name": "Chen Liang",
@@ -14,11 +14,16 @@
         {
             "name": "Jingfeng Liu",
             "email": "liujingfeng.a@yuewen.com"
+        },
+        {
+            "name": "Yong Zhang",
+            "email": "bob_zy@yeah.net"
         }
     ],
     "minimum-stability": "stable",
     "require": {
         "php": ">=5.6",
+        "phptars/tars-utils": "~0.3",
         "phptars/tars-client": "~0.2",
         "phptars/tars-report": "~0.1",
         "phptars/tars-config": "~0.1",

--- a/src/cmd/Start.php
+++ b/src/cmd/Start.php
@@ -26,8 +26,7 @@ class Start extends CommandBase
         $serverName = $tarsServerConfig['server'];
 
         //检查必须的服务名是否存在
-        if (empty($application)
-            || empty($serverName)) {
+        if (empty($application) || empty($serverName)) {
             echo 'AppName or ServerName empty! Please check config!' . PHP_EOL;
             exit;
         }
@@ -36,25 +35,44 @@ class Start extends CommandBase
         $basePath = $tarsServerConfig['basepath'];
 
         $servicesInfo = require $basePath . 'src/services.php';
-        if ($tarsServerConfig['servType'] === 'tcp') {
-            if (!isset($servicesInfo['home-class']) ||
-                !isset($servicesInfo['home-api'])) {
-                echo 'home-class or home-api not exist, please chech services.php!'
-                    . PHP_EOL;
+
+        //老版本检查，提示, 新版本中services.php中应该是objName 为key 的二维数组
+        if (isset($servicesInfo['home-class']) || isset($servicesInfo['home-api'])  || isset($servicesInfo['namespace'])) {
+            echo 'you use old version service.php, need update, please check services.php!' . PHP_EOL;
+            exit();
+        }
+
+        foreach ($tarsServerConfig['adapters'] as $key => $adapter) {
+            if (empty($servicesInfo[$adapter['objName']])) {
+                echo $adapter['objName'] . ' not defined in services.php, please check it!' . PHP_EOL;
+                exit();
+            }
+
+            $serviceInfo = $servicesInfo[$adapter['objName']];
+
+            if (!isset($serviceInfo['serverType'])) {
+                $servicesInfo[$adapter['objName']]['serverType'] = $adapter['protocol'] == 'not_tars' || $adapter['protocol'] == 'not_taf' ? 'http' : 'tcp';
+            }
+
+            if (!isset($serviceInfo['protocolName'])) {
+                $servicesInfo[$adapter['objName']]['serverType'] = $adapter['protocol'] == 'not_tars' || $adapter['protocol'] == 'not_taf' ? 'http' : 'tars';
+            }
+
+            if (in_array($servicesInfo[$adapter['objName']]['serverType'], ['tcp', 'udp'])
+                && (!isset($serviceInfo['home-class']) || !isset($serviceInfo['home-api']))) {
+                echo $adapter['objName'] . ' home-class or home-api not exist, please check services.php!' . PHP_EOL;
                 exit;
             }
-            $tarsServerConfig['servicesInfo'] = $servicesInfo;
-        } else {
-            $tarsServerConfig['servicesInfo'] = $servicesInfo;
         }
+
+        $tarsServerConfig['servicesInfo'] = $servicesInfo;
 
         $tarsConfig['tars']['application']['server'] = $tarsServerConfig;
 
         $name = $application . '.' . $serverName;
         $ret = $this->getProcess($name);
         if ($ret['exist'] === true) {
-            echo "{$name} start  \033[34;40m [FAIL] \033[0m process already exists"
-                . PHP_EOL;
+            echo "{$name} start  \033[34;40m [FAIL] \033[0m process already exists" . PHP_EOL;
             exit;
         }
 

--- a/src/core/TarsPlatform.php
+++ b/src/core/TarsPlatform.php
@@ -21,7 +21,6 @@ class TarsPlatform
         // 加载tars需要的文件 - 最好是通过autoload来加载
         // 初始化的上报
         $serverInfo = new \Tars\report\ServerInfo();
-        $serverInfo->adapter = $tarsServerConf['adapters'][0]['adapterName'];
         $serverInfo->application = $tarsServerConf['app'];
         $serverInfo->serverName = $tarsServerConf['server'];
         $serverInfo->pid = $master_pid;
@@ -29,7 +28,11 @@ class TarsPlatform
 
         $serverF = App::getServerF();
         try {
-            $serverF->keepAlive($serverInfo);
+            foreach ($tarsServerConf['adapters'] as $adapterObj) {
+                $serverInfo->adapter = $adapterObj['adapterName'];
+                $serverF->keepAlive($serverInfo);
+            }
+
             $serverInfo->adapter = 'AdminAdapter';
             $serverF->keepAlive($serverInfo);
         } catch (\Exception $e) {
@@ -77,18 +80,20 @@ class TarsPlatform
         $application = $data['application'];
         $serverName = $data['serverName'];
         $masterPid = $data['masterPid'];
-        $adapter = $data['adapter'];
+        $adapters = $data['adapters'];
 
         // 进行一次上报
         $serverInfo = new \Tars\report\ServerInfo();
-        $serverInfo->adapter = $adapter;
         $serverInfo->application = $application;
         $serverInfo->serverName = $serverName;
         $serverInfo->pid = $masterPid;
 
         try {
             $serverF = App::getServerF();
-            $serverF->keepAlive($serverInfo);
+            foreach ($adapters as $adapter) {
+                $serverInfo->adapter = $adapter;
+                $serverF->keepAlive($serverInfo);
+            }
 
             $adminServerInfo = new \Tars\report\ServerInfo();
             $adminServerInfo->adapter = 'AdminAdapter';


### PR DESCRIPTION
支持多个servant
1. 使用swoole addListener 做底层支持
2. 支持一个服务部署多个obj，分别使用tars 或 http 协议
3. services.php 格式调整，返回以objName 为key 的二维数组。
4.  protocolName, serverType, isTimer 不在从私有模板中读取，需要在services.php中指定
5. demo见TarsActDemo下的QD.UserService 服务（timer见tars-timer-server服务）。